### PR TITLE
add new option  which is not required

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,7 @@ import { createCoverageMap, CoverageMapData, CoverageSummary } from "istanbul-li
 import type { FormattedTestResults } from "@jest/test-result/build/types"
 
 const ACTION_NAME = "jest-github-action"
-const COVERAGE_HEADER = "# :open_umbrella: Code Coverage";
+const COVERAGE_HEADER = core.getInput("coverage-header", { required: false }) || "# :open_umbrella: Code Coverage";
 const CHAR_LIMIT = 60000;
 
 const rootPath = process.cwd();


### PR DESCRIPTION
Add coverage-header option so that in case of multiple comments, we can differentiate between them